### PR TITLE
fix the parsing of the response of the PadWalker version request

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -616,7 +616,7 @@ export class perlDebuggerConnection {
 
 	async getPadwalkerVersion(): Promise<string> {
 		const res = await this.request('print $DB::OUT eval { require PadWalker; PadWalker->VERSION() }');
-		const version = res.data[0];
+		const version = res.data[1];
 		if (/^[0-9]+\.?([0-9]?)+$/.test(version)) {
 			return version;
 		}


### PR DESCRIPTION
The version string was previously retrieved improperly which made `getPadwalkerVersion` wrongly report that PadWalker is not installed.