### PR TITLE
Make tests debuggable from inside vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -35,6 +35,25 @@
 			"internalConsoleOptions": "openOnSessionStart"
 		},
 		{
+			"name": "Run Tests in vscode (mocha)",
+			"type": "extensionHost",
+			"request": "launch",
+			"runtimeExecutable": "${execPath}",
+			"args": [
+				"--extensionDevelopmentPath=${workspaceFolder}",
+				"--extensionTestsPath=${workspaceFolder}/out/tests"
+			],
+			"outFiles": [
+				"${workspaceFolder}/out/tests/**/*.js"
+			],
+			"preLaunchTask": "npm: watch",
+			"stopOnEntry": false,
+			"env": {
+				// FIXME: https://github.com/raix/vscode-perl-debug/issues/53
+				"PERL5LIB": "."
+			}
+		},
+		{
 			"type": "perl",
 			"request": "launch",
 			"name": "Run Perl Debugger",

--- a/src/tests/adapter.test.ts
+++ b/src/tests/adapter.test.ts
@@ -120,7 +120,7 @@ describe('Perl debug Adapter', () => {
 			]);
 		});
 
-		test.skip('should stop on entry', async () => {
+		it.skip('should stop on entry', async () => {
 			const PROGRAM = Path.join(DATA_ROOT, FILE_FAST_TEST_PL);
 			const ENTRY_LINE = 5;
 
@@ -143,7 +143,7 @@ describe('Perl debug Adapter', () => {
 			await dc.hitBreakpoint(Configuration({ program: PROGRAM }), { path: PROGRAM, line: BREAKPOINT_LINE } );
 		});
 
-		test.skip('hitting a lazy breakpoint should send a breakpoint event', () => {
+		it.skip('hitting a lazy breakpoint should send a breakpoint event', () => {
 
 			const PROGRAM = Path.join(DATA_ROOT, FILE_FAST_TEST_PL);
 			const BREAKPOINT_LINE = 6;

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -1,0 +1,9 @@
+import * as testRunner from 'vscode/lib/testrunner';
+
+testRunner.configure({
+    ui: 'bdd',
+    useColors: true,
+    timeout: 2000
+});
+
+module.exports = testRunner;


### PR DESCRIPTION
I cannot say I understand most of the technologies involved here, but these changes allow me to debug the tests from inside vscode with breakpoints and such. This uses the »hello world« test runner which is based on Mocha as I understand it; for that reason, I had to change skip tests so they run in mocha and jest.