### PR TITLE
Cleanup tslint/vscode warnings, require more recent vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,6 +17,7 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Run Server",
+			"preLaunchTask": "yarn",
 			"cwd": "${workspaceFolder}",
 			"program": "${workspaceFolder}/src/perlDebug.ts",
 			"args": [ "--server=4711" ],
@@ -27,11 +28,14 @@
 			"type": "node",
 			"request": "launch",
 			"name": "Run Tests",
+			"preLaunchTask": "yarn",
 			"cwd": "${workspaceFolder}",
 			"program": "yarn test",
 			"args": [],
 			"sourceMaps": true,
-			"outDir": "${workspaceFolder}/out",
+			"outFiles": [
+				"${workspaceFolder}/out/tests/**/*.js"
+			],
 			"internalConsoleOptions": "openOnSessionStart"
 		},
 		{
@@ -52,10 +56,11 @@
 			}
 		},
 		{
+			"root": "${workspaceFolder}/",
 			"type": "perl",
 			"request": "launch",
 			"name": "Run Perl Debugger",
-			"program": "${workspaceFolder}/${command.AskForProgramName}",
+			"program": "${workspaceFolder}/${command:AskForProgramName}",
 			"stopOnEntry": true
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": ">=1.1.10",
+    "vscode": ">=1.9.0",
     "node": ">=8.0.0"
   },
   "icon": "images/vscode-perl-debug.png",

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -237,7 +237,7 @@ class PerlDebugSession extends LoggingDebugSession {
 		const newBreakpoints: string[] = args.breakpoints.map(bp => { return bp.name });
 		const neoBreakpoints: DebugProtocol.FunctionBreakpoint[] = [];
 
-		for (var i = 0; i < this._functionBreakPoints.length; i++) {
+		for (let i = 0; i < this._functionBreakPoints.length; i++) {
 			const name = this._functionBreakPoints[i];
 			if (newBreakpoints.indexOf(name) < 0) {
 				this.sendEvent(new OutputEvent(`Remove ${name}\n`));
@@ -245,7 +245,7 @@ class PerlDebugSession extends LoggingDebugSession {
 			}
 		}
 
-		for (var i = 0; i < args.breakpoints.length; i++) {
+		for (let i = 0; i < args.breakpoints.length; i++) {
 			const bp = args.breakpoints[i];
 			if (this._functionBreakPoints.indexOf(bp.name) < 0) {
 				breakpoints.push(bp.name);
@@ -398,8 +398,7 @@ class PerlDebugSession extends LoggingDebugSession {
 	 */
 	private async setBreakPointsRequestAsync(response: DebugProtocol.SetBreakpointsResponse, args: DebugProtocol.SetBreakpointsArguments): Promise<DebugProtocol.SetBreakpointsResponse> {
 
-		var path = args.source.path;
-		var clientLines = args.lines;
+		const path = args.source.path;
 
 		const debugPath = await this.perlDebugger.relativePath(path);
 		const editorExisting = this._breakPoints.get(path);
@@ -408,7 +407,7 @@ class PerlDebugSession extends LoggingDebugSession {
 		const debuggerPBs: number[] = (await this.perlDebugger.getBreakPoints())[debugPath] || [];
 		const createBP: number[] = [];
 		const removeBP: number[] = [];
-		var breakpoints = new Array<Breakpoint>();
+		const breakpoints = new Array<Breakpoint>();
 
 		// Clean up debugger removing unset bps
 		for (let i = 0; i < debuggerPBs.length; i++) {
@@ -732,7 +731,9 @@ class PerlDebugSession extends LoggingDebugSession {
 			}
 		});
 
-		if (endFrame) frames.unshift(endFrame);
+		if (endFrame) {
+			frames.unshift(endFrame);
+		}
 
 		response.body = {
 			stackFrames: frames,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "ES5",
+		"target": "es6",
 		"module": "commonjs",
 		"moduleResolution": "node",
 		"inlineSourceMap": true,


### PR DESCRIPTION
* target es6
* Require at least 2 years old version of vscode for runInTerminal support
* fix line number (broke due to independent PRs?)
* vscode deprecations and warnings in launch.json
* address tslint complaints
