### PR TITLE
support for loaded sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": ">=1.9.0",
+    "vscode": ">=1.19.0",
     "node": ">=8.0.0"
   },
   "icon": "images/vscode-perl-debug.png",
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "await-notify": "1.0.1",
-    "vscode-debugadapter": "1.19.0",
-    "vscode-debugprotocol": "1.19.0"
+    "vscode-debugadapter": "1.24.0",
+    "vscode-debugprotocol": "1.24.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",
@@ -62,7 +62,7 @@
     "tslint": "5.8.0",
     "typescript": "2.7.1",
     "vscode": "1.1.30",
-    "vscode-debugadapter-testsupport": "1.19.0"
+    "vscode-debugadapter-testsupport": "1.24.0"
   },
   "scripts": {
     "prepublish": "tsc",

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,7 @@ A debugger for perl in vs code.
 ![Perl Debug](images/vscode-perl-debugger.gif)
 
 ### Features
+
 * Breakpoints *(continue, step over, step in, step out)*
 * Stacktrace
 * Variable inspection *(support for objects, arrays, strings, numbers and boolean)*
@@ -16,6 +17,7 @@ A debugger for perl in vs code.
 * Setting new values of variables *(works inside of arrays and objects too)*
 * Debug console for writing expressions *(write perl expressions in the debug console)*
 * Variable values on hover in code
+* Loaded modules view *(including source code retrieval from remote)*
 
 ### Settings
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -115,6 +115,7 @@ export class perlDebuggerConnection {
 	public perlVersion: string;
 	public padwalkerVersion: string;
 	public commandRunning: string = '';
+	public isRemote: boolean = false;
 
 	private filename?: string;
 	private rootPath?: string;
@@ -302,10 +303,12 @@ export class perlDebuggerConnection {
 			// If no port is configured then run this locally in a fork
 			this.perlDebugger = new LocalSession(filename, cwd, args, options);
 			this.logOutput(this.perlDebugger.title());
+			this.isRemote = false;
 		} else {
 			// If port is configured then use the remote session.
 			this.logOutput(`Waiting for remote debugger to connect on port "${options.port}"`);
 			this.perlDebugger = new RemoteSession(options.port);
+			this.isRemote = true;
 		}
 
 		this.commandRunning = this.perlDebugger.title();

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -602,7 +602,7 @@ export class perlDebuggerConnection {
 	async getLoadedFiles(): Promise<string[]> {
 
 		const loadedFiles = await this.getExpressionValue(
-			`join "\t", grep { /^_</ } keys %main::`
+			'join "\t", grep { /^_</ } keys %main::'
 		);
 
 		return loadedFiles

--- a/src/tests/remote.test.ts
+++ b/src/tests/remote.test.ts
@@ -81,15 +81,31 @@ describe('Perl debugger connection', () => {
 		assert.equal(res.ln, 7); // The first code line in test.pl is 7
 	});
 
-	it.skip('Should be able to get loaded scripts and their source code from' + FILE_TEST_PL, async () => {
+	it('Should be able to get loaded scripts and their source code from' + FILE_TEST_PL, async () => {
 
 		const [ server, local ] = setupDebugger(
 			conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions
 		);
 
-		// TODO(bh): Test for `loadedSourcesRequest` and `sourceRequest`.
-		// Those would need a `DebugClient` and/or a `DebugSession`. Not
-		// Clear how to get those here, or how to restructure the tests.
+		// Wait for result
+		const res = await server;
+
+		const loadedFiles = await conn.getLoadedFiles();
+		const modulePms = loadedFiles.filter(
+			x => x.endsWith('Module.pm')
+		);
+
+		assert.ok(
+			modulePms.length > 0,
+			'Must have loaded a `Module.pm` file'
+		);
+
+		const sourceCode = await conn.getSourceCode(modulePms[0]);
+
+		assert.ok(
+			sourceCode.indexOf('Hello module') > 0,
+			'Module.pm source code contains "Hello module"'
+		);
 
 	});
 


### PR DESCRIPTION
With this you get »Loaded Scripts« in the debugging sidebar, showing all the files Perl has loaded, including the ability to open the relevant files. This also works for remote debugging (the debugger stores the loaded code up to `__END__` markers, and the extension retrieves the code through there) including the ability to set breakpoints. No tests yet though.