### PR TITLE
feat(fork): support for multi-session/multi-process/fork debugging

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -18,6 +18,8 @@ Details are in:
 
 #### The user running debugger
 
+<!-- FIXME(bh): this is outdated -->
+
 1. The extension starts up in a separate process from vscode, a `debug server`
 2. The `debug server` will then spawn `perl5db` - somthing like `perl -d` *(unless overwritten by user settings)*
 
@@ -37,6 +39,14 @@ The [perlDebug.ts](src/perlDebug.ts) is the layer wiring up the perl5db `adapter
 *There are some gotchas around how `filenames` and `paths` are handled in the different places - actually mostly between perl and node - and mostly around absolute/relative paths and system path separators.*
 
 *Theres also some inconsistencies in how the vs code debug api handles variables/breakpoints vs watchers etc. making somethings hard to keep track of - things we might workaround later on*
+
+#### Running extension.ts and perlDebug.ts in the same process
+
+In `extension.ts` you can set `EMBED_DEBUG_ADAPTER` to `true` during
+development. Visual Studio Code will then run the extension and any
+instance of the debug adapter in the same process, so you can have
+breakpoints in `extension.ts` and other parts of the code that work
+during the same session. This option is not suitable for releases.
 
 #### Test coverage
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": ">=1.19.0",
+    "vscode": ">=1.30.0",
     "node": ">=8.0.0"
   },
   "icon": "images/vscode-perl-debug.png",
@@ -44,8 +44,8 @@
   },
   "dependencies": {
     "await-notify": "1.0.1",
-    "vscode-debugadapter": "1.24.0",
-    "vscode-debugprotocol": "1.24.0"
+    "vscode-debugadapter": "1.34.0",
+    "vscode-debugprotocol": "1.34.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",
@@ -62,7 +62,7 @@
     "tslint": "5.8.0",
     "typescript": "2.7.1",
     "vscode": "1.1.30",
-    "vscode-debugadapter-testsupport": "1.24.0"
+    "vscode-debugadapter-testsupport": "1.34.0"
   },
   "scripts": {
     "prepublish": "tsc",
@@ -103,7 +103,7 @@
       {
         "type": "perl",
         "label": "Perl Debug",
-        "program": "./out/perlDebug.js",
+        "program": "./out/debugAdapter.js",
         "runtime": "node",
         "languages": [
           "perl"
@@ -192,7 +192,8 @@
                   "integratedTerminal",
                   "externalTerminal",
                   "remote",
-                  "none"
+                  "none",
+                  "_attach"
                 ],
                 "description": "Where to launch the debug target",
                 "default": "integratedTerminal"
@@ -201,6 +202,21 @@
                 "type": "boolean",
                 "description": "Log raw I/O with debugger in output channel",
                 "default": false
+              },
+              "debugLog": {
+                "type": "boolean",
+                "description": "Log debug messages in output channel",
+                "default": false
+              },
+              "sessions": {
+                "type": "string",
+                "description": "How to handle forked children or multiple connections",
+                "default": "single",
+                "enum": [
+                  "single",
+                  "watch",
+                  "break"
+                ]
               }
             }
           }
@@ -218,7 +234,10 @@
             "inc": [],
             "args": [],
             "env": {},
-            "stopOnEntry": true
+            "debugRaw": false,
+            "debugLog": false,
+            "stopOnEntry": true,
+            "sessions": "single"
           },
           {
             "type": "perl",
@@ -228,7 +247,8 @@
             "program": "${workspaceFolder}/${relativeFile}",
             "root": "${workspaceRoot}/",
             "stopOnEntry": true,
-            "port": 5000
+            "port": 5000,
+            "sessions": "single"
           }
         ]
       }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -176,10 +176,6 @@ export class perlDebuggerConnection extends EventEmitter {
 			special: [],
 		};
 
-		if (res.orgData.filter(x => /vscode:/.test(x)).length > 0) {
-			let abc = 123;
-		}
-
 		res.orgData.forEach((line, i) => {
 			if (i === 0) {
 				// Command line

--- a/src/attachSession.ts
+++ b/src/attachSession.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import * as net from 'net';
+import { Readable, Writable } from 'stream';
+import { EventEmitter } from 'events';
+import { DebugSession } from './session';
+
+export class AttachSession extends EventEmitter implements DebugSession {
+	public stdin: Writable;
+	public stdout: Readable;
+	public stderr: Readable;
+	public kill: Function;
+	public title: Function;
+	public port: Number | null;
+
+	constructor(port: number, address: string = "localhost") {
+		super();
+
+		const client: net.Socket = new net.Socket();
+
+		client.connect(port, address, () => {
+			this.emit('connect');
+			console.log('connect!');
+		});
+
+		this.stdin = new Writable({
+			write(chunk, encoding, callback) {
+				if (client) {
+					client.write(chunk);
+					callback();
+				}
+				// FIXME(bh): "The callback method must be called to signal
+				// either that the write completed successfully or failed
+				// with an error. The first argument passed to the callback
+				// must be the Error object if the call failed or null if
+				// the write succeeded." - nodejs documentation
+			},
+		});
+
+		this.stdout = new Readable({
+			read() {},
+		});
+		this.stderr = new Readable({
+			read() {},
+		});
+
+		client.on('data', data => {
+			this.stderr.push(data);
+		});
+
+		client.on('close', error => {
+			this.emit('close', error);
+			this.kill();
+		});
+
+		client.on('error', data => {
+			this.emit('error', data);
+			this.kill();
+		});
+
+		this.title = () => `${client.localAddress}:${client.localPort
+			} attached to ${client.remoteAddress}:${client.remotePort}`;
+
+		this.kill = () => {
+			if (client) {
+				client.removeAllListeners();
+				client.destroy();
+			}
+			this.removeAllListeners();
+		};
+
+	}
+}

--- a/src/attachable.ts
+++ b/src/attachable.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as net from 'net';
+import {spawn} from 'child_process';
+import { Readable, Writable } from 'stream';
+import { EventEmitter } from 'events';
+import { fstat } from 'fs';
+
+export class Attachable extends EventEmitter {
+	public kill: Function;
+	public port: Number | null;
+
+	// This is a simple proxy server. When the extension launches a
+	// debuggee, it launches a server that listens on a port, then
+	// it launches the debuggee with an instruction to connect to
+	// that port. Later on, the debuggee might `fork` a child. The
+	// child runs under a new instance of the debugger, which will
+	// eventually attempt to create a new connection to that port.
+	//
+	// In order to show this separate instance in the vscode user
+	// interface (in a separate debug console, in an extended call
+	// stack hierarchy) a new debug session has to be launched. A
+	// new debug session implies a new instance of `perlDebug.ts`.
+	// This new instance will typically be in a separate process.
+	//
+	// So we have one instance of `perlDebug.ts` that accepts new
+	// connections from the debugger, and another instance that is
+	// supposed to connect to connections accepted by the other
+	// process. There is no easy and portable way to hand off the
+	// socket from one process to the other.
+	//
+	// So another level of indirection is added, the `perlDebug.ts`
+	// instance that accepts the secondary connection spawns a new
+	// proxy server that the new `perlDebug.ts` process can connect
+	// to. An `Attachable` encapsulates the proxying server. The
+	// new `perlDebug.ts` process then initiates an `AttachSession`
+	// that connects to the `Attachable`,
+
+	constructor(base: net.Socket) {
+		super();
+
+		// Keep track of the chat clients
+		let client: net.Socket;
+
+		const server = net.createServer((socket) => {
+			const name = `${socket.remoteAddress}:${socket.remotePort}`;
+
+			if (!client) {
+				client = socket;
+			} else {
+				// Already have a client connected, lets close and notify user
+				socket.destroy('Remote debugger already connected!');
+			}
+
+			base.on('data', data => {
+				if (!socket.write(data)) {
+					base.pause();
+				}
+			});
+
+			socket.on('data', data => {
+				if (!base.write(data)) {
+					socket.pause();
+				}
+			});
+
+			socket.on('drain', () => {
+				base.resume();
+			});
+
+			base.on('drain', () => {
+				socket.resume();
+			});
+
+			base.on('close', error => {
+				socket.destroy();
+			});
+
+			socket.on('close', error => {
+				base.destroy();
+				this.kill();
+			});
+		});
+
+		// Listen to port make it remotely available
+		server.listen(0, 'localhost', () => {
+			this.port = server.address().port;
+			this.emit('listening', server.address());
+		});
+
+		server.on('error', data => {
+			this.emit('error', data);
+			this.kill();
+		});
+
+		this.kill = () => {
+
+			if (client) {
+				client.removeAllListeners();
+				client.destroy();
+				client = null;
+			}
+
+			server.removeAllListeners();
+			server.close();
+			this.removeAllListeners();
+
+		};
+
+	}
+}

--- a/src/debugAdapter.ts
+++ b/src/debugAdapter.ts
@@ -1,0 +1,3 @@
+import { PerlDebugSession } from './perlDebug';
+
+PerlDebugSession.run(PerlDebugSession);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,47 @@
 'use strict';
 
+import * as Net from 'net';
 import * as vscode from 'vscode';
 import * as path from 'path';
 import {
 	WorkspaceFolder, DebugConfiguration, ProviderResult,
 	CancellationToken
 } from 'vscode';
+import { PerlDebugSession } from './perlDebug';
+
+/*
+ * Set the following compile time flag to true if the
+ * debug adapter should run inside the extension host.
+ * Please note: the test suite does not (yet) work in this mode.
+ */
+const EMBED_DEBUG_ADAPTER = false;
 
 let perlDebugOutputChannel: vscode.OutputChannel | undefined;
 let streamCatcherOutputChannel: vscode.OutputChannel | undefined;
+
+function handlePerlDebugEvent(
+	event: vscode.DebugSessionCustomEvent
+) {
+
+	if (!perlDebugOutputChannel) {
+
+		perlDebugOutputChannel = vscode.window.createOutputChannel(
+			'Perl Debug Log'
+		);
+
+		perlDebugOutputChannel.show(true);
+
+	}
+
+	perlDebugOutputChannel.appendLine(
+		JSON.stringify([
+			new Date().toISOString(),
+			event.event,
+			...event.body,
+		])
+	);
+
+}
 
 function handleStreamCatcherEvent(
 	event: vscode.DebugSessionCustomEvent
@@ -34,6 +67,56 @@ function handleStreamCatcherEvent(
 
 }
 
+function handleAttachableEvent(
+	event: vscode.DebugSessionCustomEvent
+) {
+
+	// FIXME(bh): When the user terminates the first/main process, and
+	// perhaps even if it exits before child or other processes do, we
+	// sever their connections to the extension, but probably do not
+	// kill them properly. It is not clear whether they should in fact
+	// be killed, it might be better to tell the user that terminating
+	// the main debug adapter instance in that situation is not a good
+	// idea. Sadly vscode does not offer many better alternatives here,
+	// short of hosting the main server that accepts `perl5db.pl`
+	// connections in the extension, but then we would not have access
+	// to the selected launch configuration, or would need more hacks
+	// to get that (when the user has a pre-configured port specified).
+
+	const config: vscode.DebugConfiguration = {
+		...vscode.debug.activeDebugSession.configuration,
+		type: 'perl',
+		request: 'launch',
+
+		// Sadly better https://github.com/Microsoft/vscode/issues/70104
+		// names do not seem possible at the moment, but that may change.
+		name: `auto ${event.body.src.address}:${event.body.src.port}`,
+
+		port: event.body.dst.port,
+
+		// The `console` attribute is abused here to make a pseudo-attach
+		// request. The main reason is that actual `attachRequest` setups
+		// would cause vscode to offer a "disconnect" button rather than
+		// a stop/terminate button in the debugging toolbar, which is not
+		// what would happen when users press it, since we actually will
+		// try to terminate the debuggee.
+		console: "_attach",
+
+		// FIXME(bh): not sure if this actually needs to be overridden.
+		debugServer: null,
+	};
+
+	vscode.debug.startDebugging(
+		undefined,
+		config
+	).then((...x) => {
+		vscode.debug.activeDebugConsole.appendLine(
+			`Child session ${event.body.src.address}:${event.body.src.port}`
+		);
+	});
+
+}
+
 function handleCustomEvent(event: vscode.DebugSessionCustomEvent) {
 
 	if (event.session.type !== 'perl') {
@@ -44,6 +127,12 @@ function handleCustomEvent(event: vscode.DebugSessionCustomEvent) {
 		case 'perl-debug.streamcatcher.write':
 		case 'perl-debug.streamcatcher.data':
 			handleStreamCatcherEvent(event);
+			break;
+		case 'perl-debug.attachable.listening':
+			handleAttachableEvent(event);
+			break;
+		case 'perl-debug.debug':
+			handlePerlDebugEvent(event);
 			break;
 		case 'perl-debug.streamcatcher.clear':
 			if (streamCatcherOutputChannel) {
@@ -71,6 +160,12 @@ export function activate(context: vscode.ExtensionContext) {
 			handleCustomEvent
 		)
 	);
+
+	if (EMBED_DEBUG_ADAPTER) {
+		const factory = new PerlDebugAdapterDescriptorFactory();
+		context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('perl', factory));
+		context.subscriptions.push(factory);
+	}
 
 }
 
@@ -107,14 +202,59 @@ class PerlDebugConfigurationProvider implements vscode.DebugConfigurationProvide
 			return undefined;
 		}
 
+		// TODO(bh): Given that `package.json` specifies various default
+		// values for the launch configuration, perhaps this should start
+		// with the defaults, merge in the actually specified options,
+		// and then make final adjustments? Otherwise there is a chance
+		// default values end up being ignored.
+
 		if (config.port && !config.console) {
 			config.console = 'remote';
+		}
+
+		if (!config.sessions) {
+			config.sessions = 'single';
 		}
 
 		if (!config.console) {
 			config.console = 'integratedTerminal';
 		}
 
+		// map config.inc as leading -I execArgs
+		config.execArgs = (config.inc || [])
+			.map(d => `-I${d}`)
+			.concat(config.execArgs || []);
+
 		return config;
+	}
+}
+
+
+class PerlDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
+
+	private server?: Net.Server;
+
+	createDebugAdapterDescriptor(
+		session: vscode.DebugSession,
+		executable: vscode.DebugAdapterExecutable | undefined
+	): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+
+		if (!this.server) {
+			// start listening on a random port
+			this.server = Net.createServer(socket => {
+				const session = new PerlDebugSession();
+				session.setRunAsServer(true);
+				session.start(<NodeJS.ReadableStream>socket, socket);
+			}).listen(0);
+		}
+
+		// make VS Code connect to debug server
+		return new vscode.DebugAdapterServer(this.server.address().port);
+	}
+
+	dispose() {
+		if (this.server) {
+			this.server.close();
+		}
 	}
 }

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -13,7 +13,7 @@ import {readFileSync} from 'fs';
 import {basename, dirname, join} from 'path';
 import {spawn, ChildProcess} from 'child_process';
 const { Subject } = require('await-notify');
-import { perlDebuggerConnection } from './adapter';
+import { perlDebuggerConnection, RequestResponse } from './adapter';
 import { variableType, ParsedVariable, ParsedVariableScope, resolveVariable } from './variableParser';
 
 /**
@@ -44,6 +44,8 @@ export interface LaunchRequestArguments extends DebugProtocol.LaunchRequestArgum
 	console?: string,
 	/** Log raw I/O with debugger in output channel */
 	debugRaw?: boolean,
+	/** How to handle forked children or multiple connections */
+	sessions?: string,
 }
 
 export class PerlDebugSession extends LoggingDebugSession {
@@ -51,17 +53,10 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	private _breakpointId = 1000;
 
-	// This is the next line that will be 'executed'
-	private __currentLine = 0;
-	private get _currentLine() : number {
-		return this.__currentLine;
-    }
-	private set _currentLine(line: number) {
-		this.__currentLine = line;
-	}
-
 	private _breakPoints = new Map<string, DebugProtocol.Breakpoint[]>();
-	private _functionBreakPoints: string[] = [];
+
+	private _functionBreakPoints: Map<string, DebugProtocol.Breakpoint>
+		= new Map<string, DebugProtocol.Breakpoint>();
 
 	private _loadedSources = new Map<string, Source>();
 
@@ -69,12 +64,12 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	public dcSupportsRunInTerminal: boolean = false;
 
-	private perlDebugger: perlDebuggerConnection;
+	private adapter: perlDebuggerConnection;
 
 	public constructor() {
 		super('perl_debugger.log');
 
-		this.perlDebugger = new perlDebuggerConnection();
+		this.adapter = new perlDebuggerConnection();
 
 		this.setDebuggerLinesStartAt1(false);
 		this.setDebuggerColumnsStartAt1(false);
@@ -96,11 +91,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		this.dcSupportsRunInTerminal = !!args.supportsRunInTerminalRequest;
 
-		this.perlDebugger.on('perl-debug.output', (text) => {
+		this.adapter.on('perl-debug.output', (text) => {
 			this.sendEvent(new OutputEvent(`${text}\n`));
 		});
 
-		this.perlDebugger.on('perl-debug.exception', (res) => {
+		this.adapter.on('perl-debug.exception', (res) => {
 			// xxx: for now I need more info, code to go away...
 			const [ error ] = res.errors;
 			this.sendEvent(
@@ -108,25 +103,49 @@ export class PerlDebugSession extends LoggingDebugSession {
 			);
 		});
 
-		this.perlDebugger.on('perl-debug.termination', (x) => {
+		this.adapter.on('perl-debug.termination', (x) => {
 			this.sendEvent(new TerminatedEvent());
 		});
 
-		this.perlDebugger.on('perl-debug.close', (x) => {
+		this.adapter.on('perl-debug.stopped', (x) => {
+			// FIXME(bh): `breakpoint` is not always correct here.
+			this.sendEvent(new StoppedEvent("breakpoint", PerlDebugSession.THREAD_ID));
+		});
+
+		this.adapter.on('perl-debug.close', (x) => {
 			this.sendEvent(new TerminatedEvent());
 		});
 
-		this.perlDebugger.on('perl-debug.debug', (x) => {
+		this.adapter.on('perl-debug.debug', (...x) => {
+			// FIXME: needs to check launch options
 			this.sendEvent(new Event('perl-debug.debug', x));
 		});
 
-		this.perlDebugger.initializeRequest()
-			.then(() => {
-				// since this debug adapter can accept configuration requests like 'setBreakpoint' at any time,
-				// we request them early by sending an 'initializeRequest' to the frontend.
-				// The frontend will end the configuration sequence by calling 'configurationDone' request.
-				this.sendEvent(new InitializedEvent());
+		this.adapter.on('perl-debug.new-source', () => {
 
+			// FIXME(bh): There is probably a better way to re-use the code
+			// in that function that does not require setting up a malformed
+			// object here, but this seems good enough for the moment.
+			this.loadedSourcesRequestAsync(
+				{} as DebugProtocol.LoadedSourcesResponse,
+				{}
+			);
+
+		});
+
+		this.adapter.on(
+			'perl-debug.attachable.listening',
+			data => {
+				this.sendEvent(
+					new Event(
+						'perl-debug.attachable.listening', data
+					)
+				);
+			}
+		);
+
+		this.adapter.initializeRequest()
+			.then(() => {
 				// This debug adapter implements the configurationDoneRequest.
 				response.body.supportsConfigurationDoneRequest = true;
 
@@ -136,11 +155,14 @@ export class PerlDebugSession extends LoggingDebugSession {
 				// make VS Code to show a 'step back' button
 				response.body.supportsStepBack = false;
 
-				response.body.supportsFunctionBreakpoints = false;
+				response.body.supportsFunctionBreakpoints = true;
 
 				response.body.supportsLoadedSourcesRequest = true;
 
+				response.body.supportsTerminateRequest = true;
+
 				this.sendResponse(response);
+
 			});
 	}
 
@@ -155,75 +177,133 @@ export class PerlDebugSession extends LoggingDebugSession {
 		this._configurationDone.notify();
 	}
 
-	protected async launchRequest(response: DebugProtocol.LaunchResponse, args: LaunchRequestArguments) {
-		this.rootPath = args.root;
+	private stepAfterFork(
+		sessions: string,
+		launchResponse: RequestResponse
+	) {
 
-		const inc = args.inc && args.inc.length ? args.inc.map(directory => `-I${directory}`) : [];
-		const execArgs = [].concat(args.execArgs || [], inc);
-		const programArguments = args.args || [];
+		const stoppedInForkWrapper =
+			/^Devel::vscode::_fork/.test(launchResponse.data[0] || "");
+
+		const pidsInDebuggerPrompt =
+			/^\[pid=/.test(launchResponse.db);
+
+		if (stoppedInForkWrapper && sessions === 'break') {
+			// step out of the wrapper
+			this.adapter.request('s');
+		}
+
+		if (sessions === 'watch') {
+
+			this.adapter.request('c');
+			this.sendEvent(
+				new ContinuedEvent(PerlDebugSession.THREAD_ID)
+			);
+
+		} else if (sessions === 'break') {
+
+			this.sendEvent(
+				new StoppedEvent("postfork", PerlDebugSession.THREAD_ID)
+			);
+
+		}
+
+	}
+
+	protected async launchRequest(
+		response: DebugProtocol.LaunchResponse,
+		args: LaunchRequestArguments
+	) {
+
+		this.rootPath = args.root;
 
 		logger.setup(args.trace ? Logger.LogLevel.Verbose : Logger.LogLevel.Stop, false);
 
-		await this._configurationDone.wait(1000);
-
-		this.perlDebugger.removeAllListeners('perl-debug.streamcatcher.data');
-		this.perlDebugger.removeAllListeners('perl-debug.streamcatcher.write');
-		this.sendEvent(new Event('perl-debug.streamcatcher.clear'));
+		this.adapter.removeAllListeners('perl-debug.streamcatcher.data');
+		this.adapter.removeAllListeners('perl-debug.streamcatcher.write');
 
 		if (args.debugRaw) {
-			this.perlDebugger.on('perl-debug.streamcatcher.data', (...x) => {
+			this.adapter.on('perl-debug.streamcatcher.data', (...x) => {
 				this.sendEvent(new Event('perl-debug.streamcatcher.data', x));
 			});
 
-			this.perlDebugger.on('perl-debug.streamcatcher.write', (...x) => {
+			this.adapter.on('perl-debug.streamcatcher.write', (...x) => {
 				this.sendEvent(new Event('perl-debug.streamcatcher.write', x));
 			});
 		}
 
-		const launchResponse = await this.perlDebugger.launchRequest(
-			args.program,
-			args.root,
-			execArgs,
-			{
-				exec: args.exec,
-				args: programArguments,
-				env: {
-					PATH: process.env.PATH || '',
-					// PERL5OPT: process.env.PERL5OPT || '',
-					PERL5LIB: process.env.PERL5LIB || '',
-					...args.env
-				},
-				port: args.port || undefined,
-				console: args.console
-			},
+		// TODO(bh): If the user manually launches two debug sessions in
+		// parallel, this would clear output from one of the sessions
+		// when starting the other one. That is not ideal.
+		if (args.console !== '_attach') {
+			this.sendEvent(new Event('perl-debug.streamcatcher.clear'));
+		}
+
+		const launchResponse = await this.adapter.launchRequest(
+			args,
 			// Needs a reference to the session for `runInTerminal`
 			this
 		);
 
-		if (args.stopOnEntry) {
-			if (launchResponse.ln) {
-				this._currentLine = launchResponse.ln - 1;
-			}
+		// NOTE(bh): This extension used to send the `InitializedEvent`
+		// at the beginning of the `initializeRequest`. That was taken
+		// as a signal that we can accept configurations right away, but
+		// we actually need to talk to the debugger to set breakpoints
+		// without buffering them. Fixed in part thanks to the help in
+		// https://github.com/Microsoft/vscode/issues/69317
+
+		this.sendEvent(new InitializedEvent());
+
+		// With the event sent vscode should now send us breakpoint and
+		// other configuration requests and signals us that it done doing
+		// so with a `configurationDoneRequest`, so we wait here for it.
+		await this._configurationDone.wait(2000);
+
+		if (args.console === '_attach') {
+
+			this.stepAfterFork(args.sessions, launchResponse);
+
+		} else if (args.stopOnEntry) {
+
 			this.sendResponse(response);
 
 			// we stop on the first line
 			this.sendEvent(new StoppedEvent("entry", PerlDebugSession.THREAD_ID));
 		} else {
 			// we just start to run until we hit a breakpoint or an exception
-			this.continueRequest(<DebugProtocol.ContinueResponse>response, { threadId: PerlDebugSession.THREAD_ID });
+			this.continueRequest(
+				<DebugProtocol.ContinueResponse>response,
+				{
+					threadId: PerlDebugSession.THREAD_ID
+				}
+			);
 		}
 
 	}
 
 	protected threadsRequest(response: DebugProtocol.ThreadsResponse): void {
-		// xxx: Not sure if this is sufficient to levarage multi cores?
-		// return the default thread
+
+		// NOTE(bh): vscode actually shows the thread name in the user
+		// interface during multi-session debugging, at least until
+		// https://github.com/Microsoft/vscode/issues/69752 is addressed,
+		// so this tries to make a pretty name for it.
+
+		// NOTE(bh): "The use of interpreter-based threads in perl is
+		// officially discouraged." -- `perldoc threads`. This extension
+		// does not support them in any way, so we only ever report one
+		// thread per adapter instance.
+
 		response.body = {
 			threads: [
-				new Thread(PerlDebugSession.THREAD_ID, "thread 1")
+				new Thread(
+					PerlDebugSession.THREAD_ID,
+					this.adapter.getThreadName()
+				)
 			]
 		};
+
 		this.sendResponse(response);
+
 	}
 
 
@@ -235,8 +315,8 @@ export class PerlDebugSession extends LoggingDebugSession {
  * * step out
  * * step back
  * * reverse continue
+ * * data breakpoints (https://github.com/raix/vscode-perl-debug/issues/4)
  */
-
 
 	/**
 	 * Reverse continue
@@ -244,9 +324,8 @@ export class PerlDebugSession extends LoggingDebugSession {
 	protected reverseContinueRequest(response: DebugProtocol.ReverseContinueResponse, args: DebugProtocol.ReverseContinueArguments) : void {
 		this.sendEvent(new OutputEvent(`ERR>Reverse continue not implemented\n\n`));
 
+		response.success = false;
 		this.sendResponse(response);
-		// no more lines: stop at first line
-		this._currentLine = 0;
 		this.sendEvent(new StoppedEvent("entry", PerlDebugSession.THREAD_ID));
  	}
 
@@ -256,20 +335,85 @@ export class PerlDebugSession extends LoggingDebugSession {
 	protected stepBackRequest(response: DebugProtocol.StepBackResponse, args: DebugProtocol.StepBackArguments): void {
 		this.sendEvent(new OutputEvent(`ERR>Step back not implemented\n`));
 
+		response.success = false;
 		this.sendResponse(response);
-		// no more lines: stop at first line
-		this._currentLine = 0;
 		this.sendEvent(new StoppedEvent("entry", PerlDebugSession.THREAD_ID));
 	}
 
 
 
+	// protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
+	// 	response.success = false;
+	// 	this.sendResponse(response);
+	// }
 
+	private async checkSignaling(): Promise<boolean> {
 
+		if (!this.adapter.canSignalDebugger) {
+			return false;
+		}
+
+		// When we get here, it looks as though we run on the same host
+		// and our user also has a process with a process identifier that
+		// matches the one we got from the debugger. Check if we can make
+		// the debugger send us a SIGINT. If that works, we assume that
+		// the other direction works aswell. In the unlikely worst case,
+		// the signal goes to the wrong process on a different machine.
+
+		const result = Promise.race<boolean>([
+			new Promise(resolve => {
+				process.once('SIGINT', () => resolve(true))
+			}),
+			new Promise((resolve, reject) => {
+				setTimeout(() => resolve(false), 200)
+			})
+		]);
+
+	  await this.adapter.getExpressionValue(
+			`CORE::kill('INT', ${process.pid})`
+	  );
+
+	  return result;
+	}
+
+	protected async disconnectRequest(
+		response: DebugProtocol.DisconnectResponse,
+		args: DebugProtocol.DisconnectArguments
+	): Promise<void> {
+
+		await this.adapter.destroy();
+
+	}
+
+	protected async terminateRequest(
+		response: DebugProtocol.TerminateResponse,
+		args: DebugProtocol.TerminateArguments
+	): Promise<void> {
+
+		if (this.adapter.terminateDebugger()) {
+
+			// FIXME(bh): Unsure whether to do this here.
+			await this.adapter.destroy();
+
+			this.sendResponse(response);
+
+		} else {
+
+			response.success = false;
+			response.body = {
+				error: {
+					message: 'Cannot send SIGTERM to debugger on remote system'
+				}
+			};
+			this.sendResponse(response);
+
+		}
+
+	}
 
 	protected pauseRequest(response: DebugProtocol.PauseResponse, args: DebugProtocol.PauseArguments): void {
 
-		if (this.perlDebugger.isRemote) {
+		if (!this.adapter.canSignalDebugger) {
 			response.success = false;
 			response.body = {
 				error: {
@@ -281,57 +425,117 @@ export class PerlDebugSession extends LoggingDebugSession {
 		} else {
 
 			// Send SIGINT to the `perl -d` process on the local system.
-			process.kill(this.perlDebugger.debuggerPid, 'SIGINT');
+			process.kill(this.adapter.debuggerPid, 'SIGINT');
 			this.sendResponse(response);
-
-			// TODO(bh): It is not clear if we are supposed to also send a
-			// `StoppedEvent` and if we are, what the logic for that ought
-			// to be. Basically, whenever we see the `DB<N>` prompt from
-			// the debugger we are most probably stopped. That's the same
-			// for all protocol functions though, which suggests that ought
-			// to be handled centrally someplace, and not individually for
-			// each request. As it is, in any case, it does not seem to
-			// make a difference in vscode whether send one here or not.
 
 		}
 
 	}
 
+	private isValidFunctionName(name: string): boolean {
+		return /^[':A-Za-z_][':\w]*$/.test(name);
+	}
+
+	private async setFunctionBreakPointAsync(
+		bp: DebugProtocol.FunctionBreakpoint
+	): Promise<DebugProtocol.Breakpoint> {
 
 
+		if (!this.isValidFunctionName(bp.name)) {
+
+			// Report an unverified breakpoint when there is an attempt to
+			// set a function breakpoint on something that cannot be a Perl
+			// function; we cannot pass illegal names like `12345` to the
+			// debugger as it might misinterpret it as something other than
+			// a function breakpoint request.
+
+			return new Breakpoint(false);
+
+		}
+
+		const res = await this.adapter.request(`b ${bp.name}`);
+
+		if (/Subroutine \S+ not found/.test(res.data[0])) {
+			// Unverified (and ignored by the debugger), but see below.
+		}
+
+		this.sendEvent(new OutputEvent(
+			`Adding function breakpoint on ${bp.name}\n`
+		));
+
+		// NOTE(bh): This is a simple attempt to get file and line
+		// information about where the sub is defined, at least to
+		// some extent, by going through `%DB::sub`, assuming it has
+		// already been loaded and has not been defined in unusal
+		// ways. Not sure if vscode actually uses the values though.
+
+		const pathPos = await this.adapter.getExpressionValue(
+			`$DB::sub{'${this.adapter.escapeForSingleQuotes(bp.name)}'}`
+		);
+
+		const [ bpWhole, bpFile, bpFirst, bpLast ] = pathPos
+			? pathPos.match( /(.*):(\d+)-(\d+)$/ )
+			: [undefined, undefined, undefined, undefined];
+
+		return new Breakpoint(
+			!!pathPos,
+			parseInt(bpFirst),
+			undefined,
+			new Source(
+				bpFile,
+				bpFile,
+			)
+		);
+
+	}
 
 	private async setFunctionBreakPointsRequestAsync(response: DebugProtocol.SetFunctionBreakpointsResponse, args: DebugProtocol.SetFunctionBreakpointsArguments): Promise<DebugProtocol.SetFunctionBreakpointsResponse> {
-		const breakpoints: string[] = [];
-		const newBreakpoints: string[] = args.breakpoints.map(bp => { return bp.name });
-		const neoBreakpoints: DebugProtocol.FunctionBreakpoint[] = [];
 
-		for (let i = 0; i < this._functionBreakPoints.length; i++) {
-			const name = this._functionBreakPoints[i];
-			if (newBreakpoints.indexOf(name) < 0) {
-				this.sendEvent(new OutputEvent(`Remove ${name}\n`));
-				await this.perlDebugger.request(`B ${name}`);
-			}
+		// FIXME(bh): It is not clear yet how to set breakpoints on subs
+		// that are not yet loaded at program start time. Global watch
+		// expressions can be used like so:
+		//
+		//   % perl -d -e0
+		//
+		//   Loading DB routines from perl5db.pl version 1.53
+		//   Editor support available.
+		//
+		//   Enter h or 'h h' for help, or 'man perldebug' for more help.
+		//
+		//   main::(-e:1):	0
+		//   	DB<1> w *Data::Dumper::Dumper{CODE}
+		//   	DB<2> use Data::Dumper
+		//
+		//   	DB<3> r
+		//   Watchpoint 0:	*Data::Dumper::Dumper{CODE} changed:
+		//   		old value:	''
+		//   		new value:	'CODE(0x55f9e2629688)'
+		//
+		// But possibly with considerable performance impact as any
+		// watch expression would put the debugger in trace mode? Might
+		// make sense to offer that behind a `launch.json` option.
+
+		for (const [name, bp] of this._functionBreakPoints.entries()) {
+
+			// Remove breakpoint
+			await this.adapter.request(`B ${name}`);
+
 		}
 
-		for (let i = 0; i < args.breakpoints.length; i++) {
-			const bp = args.breakpoints[i];
-			if (this._functionBreakPoints.indexOf(bp.name) < 0) {
-				breakpoints.push(bp.name);
-				const res = await this.perlDebugger.request(`b ${bp.name}`);
+		this._functionBreakPoints.clear();
 
-				this.sendEvent(new OutputEvent(`Add ${bp.name}\n`));
-				const neoBreakpoint = <DebugProtocol.FunctionBreakpoint>{name: bp.name};
-				neoBreakpoints.push(neoBreakpoint);
-				response.body.breakpoints = [new Breakpoint(true, 4, 0, new Source('Module.pm', join(/* this.filepath, */ 'Module.pm')) )];
-				this.sendResponse(response);
+		for (const bp of args.breakpoints) {
 
-				this.sendEvent(new OutputEvent(`Add ${bp.name}\n`));
-			} else {
-				neoBreakpoints.push(bp);
-			}
+			this._functionBreakPoints.set(
+				bp.name,
+				await this.setFunctionBreakPointAsync(bp)
+			);
+
 		}
 
-		this._functionBreakPoints = breakpoints;
+		response.body = {
+			breakpoints: [...this._functionBreakPoints.values()]
+		};
 
 		return response;
 	}
@@ -361,7 +565,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		const name = this.getVariableName(args.name, args.variablesReference)
 			.then((variableName) => {
 
-				return this.perlDebugger.request(`${variableName}='${args.value}'`)
+				return this.adapter.request(`${variableName}='${args.value}'`)
 					.then(() => {
 						response.body = {
 							value: args.value,
@@ -381,75 +585,24 @@ export class PerlDebugSession extends LoggingDebugSession {
 	/**
 	 * Step out
 	 */
-    protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments): void {
-		this.perlDebugger.request('r')
-			.then((res) => {
-				if (res.ln) {
-					this._currentLine = this.convertDebuggerLineToClient(res.ln);
-				}
-
-				this.sendResponse(response);
-
-				if (res.finished) {
-					this.sendEvent(new TerminatedEvent());
-				} else {
-					this.sendEvent(new StoppedEvent("step", PerlDebugSession.THREAD_ID));
-				}
-				// no more lines: run to end
-			})
-			.catch(err => {
-				const [ error = err ] = err.errors || [];
-				if (err.exception) {
-					this.sendEvent(new StoppedEvent("exception", PerlDebugSession.THREAD_ID, error.near));
-				} else {
-					this.sendEvent(new OutputEvent(`ERR>StepOut error: ${error.message}\n`));
-					this.sendEvent(new TerminatedEvent());
-				}
-				response.success = false;
-				this.sendResponse(response);
-			});
+	protected stepOutRequest(response: DebugProtocol.StepOutResponse, args: DebugProtocol.StepOutArguments): void {
+		this.adapter.request('r');
+		this.sendResponse(response);
 	}
 
 	/**
 	 * Step in
 	 */
-    protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
-		this.perlDebugger.request('s')
-			.then((res) => {
-				if (res.ln) {
-					this._currentLine = this.convertDebuggerLineToClient(res.ln);
-				}
-
-				this.sendResponse(response);
-
-				if (res.finished) {
-					this.sendEvent(new TerminatedEvent());
-				} else {
-					this.sendEvent(new StoppedEvent("step", PerlDebugSession.THREAD_ID));
-				}
-				// no more lines: run to end
-			})
-			.catch(err => {
-				const [ error = err ] = err.errors || [];
-				if (err.exception) {
-					this.sendEvent(new StoppedEvent("exception", PerlDebugSession.THREAD_ID, error.near));
-				} else {
-					this.sendEvent(new OutputEvent(`ERR>StepIn error: ${error.message}\n`));
-					this.sendEvent(new TerminatedEvent());
-				}
-				response.success = false;
-				this.sendResponse(response);
-			});
+	protected stepInRequest(response: DebugProtocol.StepInResponse, args: DebugProtocol.StepInArguments): void {
+		this.adapter.request('s');
+		this.sendResponse(response);
 	}
 
 	/**
 	 * Restart
 	 */
 	private async restartRequestAsync(response: DebugProtocol.RestartResponse, args: DebugProtocol.RestartArguments): Promise<DebugProtocol.RestartResponse> {
-		const res = await this.perlDebugger.request('R')
-		if (res.ln) {
-			this._currentLine = this.convertDebuggerLineToClient(res.ln);
-		}
+		const res = await this.adapter.request('R')
 		if (res.finished) {
 			this.sendEvent(new TerminatedEvent());
 		} else {
@@ -475,11 +628,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		const path = args.source.path;
 
-		const debugPath = await this.perlDebugger.relativePath(path);
+		const debugPath = await this.adapter.relativePath(path);
 		const editorExisting = this._breakPoints.get(path);
 		const editorBPs: number[] = args.lines.map(ln => ln);
-		const dbp = await this.perlDebugger.getBreakPoints();
-		const debuggerPBs: number[] = (await this.perlDebugger.getBreakPoints())[debugPath] || [];
+		const dbp = await this.adapter.getBreakPoints();
+		const debuggerPBs: number[] = (await this.adapter.getBreakPoints())[debugPath] || [];
 		const createBP: number[] = [];
 		const removeBP: number[] = [];
 		const breakpoints = new Array<Breakpoint>();
@@ -488,7 +641,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		for (let i = 0; i < debuggerPBs.length; i++) {
 		 	const ln = debuggerPBs[i];
 			if (editorBPs.indexOf(ln) < 0) {
-				await this.perlDebugger.clearBreakPoint(ln, debugPath);
+				await this.adapter.clearBreakPoint(ln, debugPath);
 			}
 		}
 
@@ -497,7 +650,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		 	const ln = editorBPs[i];
 			if (debuggerPBs.indexOf(ln) < 0) {
 				try {
-					const res = await this.perlDebugger.setBreakPoint(ln, debugPath);
+					const res = await this.adapter.setBreakPoint(ln, debugPath);
 					const bp = <DebugProtocol.Breakpoint> new Breakpoint(true, ln);
 					bp.id = this._breakpointId++;
 					breakpoints.push(bp);
@@ -537,78 +690,25 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 * Next
 	 */
 	protected nextRequest(response: DebugProtocol.NextResponse, args: DebugProtocol.NextArguments): void {
-		this.perlDebugger.request('n')
-			.then((res) => {
-				if (res.ln) {
-					this._currentLine = this.convertDebuggerLineToClient(res.ln);
-				}
-
-				this.sendResponse(response);
-
-				if (res.finished) {
-					this.sendEvent(new TerminatedEvent());
-				} else {
-					this.sendEvent(new StoppedEvent("step", PerlDebugSession.THREAD_ID));
-				}
-				// no more lines: run to end
-			})
-			.catch(err => {
-				const [ error = err ] = err.errors || [];
-				if (err.exception) {
-					this.sendEvent(new StoppedEvent("exception", PerlDebugSession.THREAD_ID, error.near));
-				} else {
-					this.sendEvent(new OutputEvent(`ERR>Next error: ${error.message}\n`));
-					this.sendEvent(new TerminatedEvent());
-				}
-				response.success = false;
-				this.sendResponse(response);
-			});
+		this.adapter.request('n');
+		this.sendResponse(response);
 	}
-
 
 	/**
 	 * Continue
 	 */
 	protected continueRequest(response: DebugProtocol.ContinueResponse, args: DebugProtocol.ContinueArguments): void {
 
-		// NOTE(bh): "Please note: a debug adapter is not expected to
-		// send this event in response to a request that implies that
-		// execution continues, e.g. ‘launch’ or ‘continue’." -- but in
-		// our case sending the `c` command to the debugger is never
-		// acknowledged by the debugger, we cannot tell if it succeeded
-		// and the promise below is resolved only once the debugger has
-		// halted execution of the debuggee again. Without a response to
-		// the `continueRequest`, vscode does not offer users a `pause`
-		// button, so without sending this event, we cannot pause from
-		// the debug user interface. So we send the event...
+		// NOTE(bh): The code for execution control requests like this
+		// one used to delay sending a response and events until there
+		// has been a response from the debugger. That does not make
+		// sense though since we explicitly pass control the debugger,
+		// and it might not return at all until the debuggee terminates.
+		// Instead, responses are sent immediately and events are sent
+		// based on the actual state of the debugger.
 
-		this.sendEvent(new ContinuedEvent(PerlDebugSession.THREAD_ID));
-
-		this.perlDebugger.request('c')
-			.then((res) => {
-				if (res.ln) {
-					this._currentLine = this.convertDebuggerLineToClient(res.ln);
-				}
-				this.sendResponse(response);
-
-				if (res.finished) {
-					this.sendEvent(new TerminatedEvent());
-				} else {
-					this.sendEvent(new StoppedEvent("breakpoint", PerlDebugSession.THREAD_ID));
-				}
-			})
-			.catch((err) => {
-				const [ error = err ] = err.errors || [];
-				if (err.exception) {
-					this.sendEvent(new StoppedEvent("exception", PerlDebugSession.THREAD_ID, error.near));
-				} else {
-					this.sendEvent(new OutputEvent(`ERR>Continue error: ${error.message}\n`));
-					this.sendEvent(new TerminatedEvent());
-				}
-
-				response.success = false;
-				this.sendResponse(response);
-			});
+		this.adapter.request('c');
+		this.sendResponse(response);
 	}
 
 	/**
@@ -629,7 +729,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	private getVariableName(name: string, variablesReference: number): Promise<string> {
 		let id = this._variableHandles.get(variablesReference);
-		return this.perlDebugger.variableList({
+		return this.adapter.variableList({
 			global_0: 0,
 			local_0: 1,
 			closure_0: 2,
@@ -645,7 +745,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	protected variablesRequest(response: DebugProtocol.VariablesResponse, args: DebugProtocol.VariablesArguments): void {
 		const id = this._variableHandles.get(args.variablesReference);
 
-		this.perlDebugger.variableList({
+		this.adapter.variableList({
 			global_0: 0,
 			local_0: 1,
 			closure_0: 2,
@@ -686,7 +786,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		if (/^[\$|\@]/.test(args.expression)) {
 			const expression = args.expression.replace(/\.(\'\w+\'|\w+)/g, (...a) => `->{${a[1]}}`);
 
-			this.perlDebugger.getExpressionValue(expression)
+			this.adapter.getExpressionValue(expression)
 				.then(result => {
 					if (/^HASH/.test(result)) {
 						response.body = {
@@ -719,7 +819,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 * Evaluate command line
 	 */
 	private evaluateCommandLine(response: DebugProtocol.EvaluateResponse, args: DebugProtocol.EvaluateArguments) {
-		this.perlDebugger.request(args.expression)
+		this.adapter.request(args.expression)
 			.then((res) => {
 				if (res.data.length > 1) {
 					res.data.forEach((line) => {
@@ -748,12 +848,12 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		const expression = isVariable ? clientExpression.replace(/\.(\'\w+\'|\w+)/g, (...a) => `->{${a[1]}}`) : clientExpression;
 
-		let value = await this.perlDebugger.getExpressionValue(expression);
+		let value = await this.adapter.getExpressionValue(expression);
 		if (/^Can\'t use an undefined value as a HASH reference/.test(value)) {
 			value = undefined;
 		}
 
-		const reference = isVariable ? await this.perlDebugger.getVariableReference(expression) : null;
+		const reference = isVariable ? await this.adapter.getVariableReference(expression) : null;
 		if (typeof value !== 'undefined' && /^HASH|ARRAY/.test(reference)) {
 			return {
 				value: reference,
@@ -812,15 +912,11 @@ export class PerlDebugSession extends LoggingDebugSession {
 	 */
 	private async stackTraceRequestAsync(response: DebugProtocol.StackTraceResponse, args: DebugProtocol.StackTraceArguments): Promise<DebugProtocol.StackTraceResponse> {
 
-		// FIXME(bh): There is probably a better way to re-use the code
-		// in that function that does not require setting up a malformed
-		// object here, but this seems good enough for the moment.
-		await this.loadedSourcesRequestAsync(
-			{} as DebugProtocol.LoadedSourcesResponse,
-			{}
-		);
+		// TODO(bh): Maybe re-set the function breakpoints from here, if
+		// there are any newly loaded sources there most probably are new
+		// functions, and we might be trying to break on one of them...
 
-		const stacktrace = await this.perlDebugger.getStackTrace();
+		const stacktrace = await this.adapter.getStackTrace();
 		const frames = new Array<StackFrame>();
 
 		// In case this is a trace run on end, we want to return the file with the exception in the @ position
@@ -865,7 +961,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	private async loadedSourcesRequestAsync(response: DebugProtocol.LoadedSourcesResponse, args: DebugProtocol.LoadedSourcesArguments): Promise<DebugProtocol.LoadedSourcesResponse> {
 
-		const loadedFiles = await this.perlDebugger.getLoadedFiles();
+		const loadedFiles = await this.adapter.getLoadedFiles();
 
 		const newFiles = loadedFiles.filter(
 			x => !this._loadedSources.has(x)
@@ -880,9 +976,9 @@ export class PerlDebugSession extends LoggingDebugSession {
 				// open the local file rather than retrieving a read-only
 				// version of the code through the debugger (that lacks code
 				// past `__END__` markers, among possibly other limitations).
-				this.perlDebugger.isRemote
-					? this._loadedSources.size
-					: 0
+				this.adapter.canSignalDebugger
+					? 0
+					: this._loadedSources.size
 			);
 
 			this.sendEvent(new LoadedSourceEvent("new", newSource));
@@ -933,7 +1029,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		}
 
 		response.body = {
-			content: await this.perlDebugger.getSourceCode(
+			content: await this.adapter.getSourceCode(
 				args.source.path
 			)
 		};
@@ -960,7 +1056,14 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 	}
 
-}
+	// Custom requests
 
-DebugSession.run(PerlDebugSession);
+	protected customRequestx(command: string, response: DebugProtocol.Response, args: any) {
+		if (command === '...') {
+			// this....(response, args);
+		}
+		response.success = false;
+	}
+
+}
 

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -381,6 +381,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 		args: DebugProtocol.DisconnectArguments
 	): Promise<void> {
 
+		this.adapter.terminateDebugger()
 		await this.adapter.destroy();
 
 	}

--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -342,11 +342,6 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 
 
-	// protected disconnectRequest(response: DebugProtocol.DisconnectResponse, args: DebugProtocol.DisconnectArguments): void {
-	// 	response.success = false;
-	// 	this.sendResponse(response);
-	// }
-
 	private async checkSignaling(): Promise<boolean> {
 
 		if (!this.adapter.canSignalDebugger) {
@@ -383,6 +378,7 @@ export class PerlDebugSession extends LoggingDebugSession {
 
 		this.adapter.terminateDebugger()
 		await this.adapter.destroy();
+		this.sendResponse(response);
 
 	}
 

--- a/src/regExp.ts
+++ b/src/regExp.ts
@@ -1,5 +1,9 @@
 export const colors = /\u001b\[([0-9]+)m|\u001b/g;
-export const db = /^DB\<\<?([0-9]+)\>?\>$/;
+
+// TODO(bh): Perhaps unify this with debuggerSignature by making
+// whitespace entirely optional in the latter regular expression?
+export const db = /^(\[(pid=)?[0-9\->]+\])?(\[\d+\])?DB\<+([0-9]+)\>+$/;
+
 export const restartWarning = /^Warning: some settings and command-line options may be lost!/;
 
 export const breakPoint = {
@@ -51,4 +55,11 @@ export const codeErrorRuntime = /([\S|\s]+) at (\S+) line ([0-9]+)\.$/;
 // EG. PadWalker for scope investigation
 export const codeErrorMissingModule = /^(\S+) module not found - please install$/;
 
-export const debuggerSignature = /^  DB<[0-9]+> $/;
+// Optional `pidprompt` like `[pid=123->456->789]` followed by an
+// optional thread id, followed by `DB`, and for nested debuggers
+// the number of `<` and `>` corresponds to the level of nesting.
+export const debuggerSignature = /^(\[pid=[0-9>\-]+\])? (\[\d+\])? DB<+[0-9]+>+ $/;
+
+export const watchpointChange = /^Watchpoint (\d+):\t(.*) changed:/;
+export const watchpointOldval = /^\s+old value:\t'(.*)'/;
+export const watchpointNewval = /^\s+new value:\t'(.*)'/;

--- a/src/remoteSession.ts
+++ b/src/remoteSession.ts
@@ -2,8 +2,9 @@ import * as net from 'net';
 import {spawn} from 'child_process';
 import { Readable, Writable } from 'stream';
 import { EventEmitter } from 'events';
-import { DebugSession, LaunchOptions } from './session';
+import { DebugSession } from './session';
 import { debuggerSignature } from './regExp';
+import { Attachable } from './attachable';
 
 export class RemoteSession extends EventEmitter implements DebugSession {
 	public stdin: Writable;
@@ -11,14 +12,19 @@ export class RemoteSession extends EventEmitter implements DebugSession {
 	public stderr: Readable;
 	public kill: Function;
 	public title: Function;
-	public dump: Function;
 	public port: Number | null;
 
-	constructor(port: number, bindAddress: string = "0.0.0.0") {
+	constructor(
+		port: number,
+		bindAddress: string = "0.0.0.0",
+		sessions: string = 'single'
+	) {
 		super();
 
 		// Keep track of the chat clients
 		let client: net.Socket;
+
+		const attachables: Attachable[] = [];
 
 		this.stdin = new Writable({
 			write(chunk, encoding, callback) {
@@ -48,9 +54,49 @@ export class RemoteSession extends EventEmitter implements DebugSession {
 				client = socket;
 				this.stdout.push(`Remote debugger at "${name}" connected at port ${port}.`);
 			} else {
-				// Already have a client connected, lets close and notify user
-				this.stdout.push(`Warning: Additional remote client tried to connect "${name}".`);
-				socket.destroy('Remote debugger already connected!');
+
+				if (sessions && sessions !== 'single') {
+
+					// When a debuggee calls `fork()` the Perl debugger will
+					// fork the debuggee and try to connect to the same port
+					// the parent was connected to. While vscode does support
+					// multi-target/multi-process debugging, it needs a single
+					// debug adapter process for each debuggee process. And it
+					// is not possible to pass sockets past process boundaries.
+
+					// So we accept the connection here and offer a proxy to it
+					// to the perl-debug extension, informing it that a new one
+					// is available through a custom event. The `Attachable` is
+					// the proxy. The extension receives the custom event and
+					// starts a new debug session, which will then connect to
+					// the proxy in order to interact with the debugger. There
+					// can be proxy chains if a child forks into grandchildren.
+
+					this.stdout.push(`Attachable debugger at "${name}" connected at port ${port}.`);
+
+					const attachable = new Attachable(socket);
+
+					attachables.push(attachable);
+
+					attachable.on('listening', address => {
+						this.emit('perl-debug.attachable.listening', {
+							src: {
+								address: socket.remoteAddress,
+								port: socket.remotePort,
+							},
+							via: socket.address(),
+							dst: address,
+						});
+					});
+
+					return;
+
+				} else {
+					// Already have a client connected, lets close and notify user
+					this.stdout.push(`Warning: Additional remote client tried to connect "${name}".`);
+					socket.destroy('Remote debugger already connected!');
+				}
+
 			}
 
 			socket.on('data', data => {
@@ -96,6 +142,11 @@ export class RemoteSession extends EventEmitter implements DebugSession {
 		});
 
 		this.kill = () => {
+
+			// FIXME(bh): Do we actually want to kill the attachables
+			// when the main session is going away?
+			attachables.forEach(x => x.kill());
+
 			server.removeAllListeners();
 			this.removeAllListeners();
 			this.stdin.removeAllListeners();
@@ -109,9 +160,14 @@ export class RemoteSession extends EventEmitter implements DebugSession {
 
 			server.close();
 		};
-		this.title = () => `Running debug server for remote session to connect on port "${port}"`;
-		this.dump = () => `debug server port ${port}`;
-		this.dump = () => `${server.address().address}:${server.address().port} serving ${client.remoteAddress}:${client.remotePort}`;
+		this.title = () => {
+			if (server && client) {
+				return `${server.address().address}:${server.address().port
+					} serving ${client.remoteAddress}:${client.remotePort}`;
+			} else {
+				return "Inactive RemoteSession";
+			}
+		};
 
 	}
 }

--- a/src/session.ts
+++ b/src/session.ts
@@ -7,14 +7,5 @@ export interface DebugSession {
 	stdin: Writable,
 	on: Function, // support "close", "error"
 	title: Function,
-	dump: Function, // Dump debug information
 	port: Number | null;
-}
-
-export interface LaunchOptions {
-	exec?: string;
-	args?: string[];
-	env?: {},
-	port?: number;
-	console?: string;
 }

--- a/src/streamCatcher.ts
+++ b/src/streamCatcher.ts
@@ -4,6 +4,8 @@
  * it takes requests and generates a response from the streams
  */
 
+ import * as fs from 'fs';
+
 import {Writable, Readable} from 'stream';
 import * as RX from './regExp';
 import { EventEmitter } from 'events';

--- a/src/tests/connection.test.ts
+++ b/src/tests/connection.test.ts
@@ -3,7 +3,7 @@ import asyncAssert from './asyncAssert';
 import * as Path from 'path';
 import { perlDebuggerConnection, RequestResponse } from '../adapter';
 import { LocalSession } from '../localSession';
-import { LaunchOptions } from '../session';
+import { LaunchRequestArguments } from '../perlDebug';
 
 const PROJECT_ROOT = Path.join(__dirname, '../../');
 const DATA_ROOT = Path.join(PROJECT_ROOT, 'src/tests/data/');
@@ -18,23 +18,29 @@ const FILE_BROKEN_CODE = 'broken_code.pl';
 const FILE_PRINT_ARGUMENTS = 'print_arguments.pl';
 const FILE_FAST_TEST_PL = 'fast_test.pl';
 
-const launchOptions: LaunchOptions = {
-	env: {
-		PATH: process.env.PATH || '',
-		PERL5LIB: process.env.PERL5LIB || '',
-	},
-	console: 'none'
-};
-
 async function testLaunch(
 	conn: perlDebuggerConnection,
 	filename: string,
 	cwd: string,
 	args: string[] = [],
-	options:LaunchOptions = {}
+	options: any = {}
 ): Promise<RequestResponse> {
 
-	return conn.launchRequest(filename, cwd, args, options, null);
+	const launchArgs: LaunchRequestArguments = {
+		env: {
+			PATH: process.env.PATH || '',
+			PERL5LIB: process.env.PERL5LIB || '',
+		},
+		console: 'none',
+		program: filename,
+		root: cwd,
+		execArgs: args,
+		exec: 'perl',
+		...options,
+		args: options.args,
+	};
+
+	return conn.launchRequest(launchArgs, null);
 
 }
 
@@ -54,31 +60,32 @@ describe('Perl debugger connection', () => {
 
 	describe('launchRequest', () => {
 		it('Should be able to connect and launch ' + FILE_TEST_PL, async () => {
-			const res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			const res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			assert.equal(res.finished, false);
 			assert.equal(res.exception, false);
 			assert.equal(res.ln, 7); // The first code line in test.pl is 5
 		});
 
 		it('Should be able to connect and launch ' + FILE_BROKEN_CODE, async () => {
-			const res = await testLaunch(conn, FILE_BROKEN_CODE, DATA_ROOT, [], launchOptions);
+			const res = await testLaunch(conn, FILE_BROKEN_CODE, DATA_ROOT, []);
 			assert.equal(res.finished, false);
 			assert.equal(res.exception, false);
 			assert.equal(res.ln, 7);
 		});
 
 		it('Should be able to connect and launch remote ' + FILE_TEST_PL, async () => {
-			const port = 5000 + Math.round(Math.random()*100); // Not to conflict with VS Code jest ext
+			const port = 0;
 			// Listen for remote debugger session
 			const server = testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], {
-				...launchOptions,
 				port, // Trigger server
 			});
 			// Start "remote" debug session
-			const local = new LocalSession(FILE_TEST_PL, DATA_ROOT, [], {
-				...launchOptions,
+			const local = new LocalSession({
+				exec: 'perl',
+				execArgs: [],
+				program: FILE_TEST_PL,
+				root: DATA_ROOT,
 				env: {
-					...launchOptions.env,
 					PERLDB_OPTS: `RemotePort=localhost:${port}`, // Trigger remote debugger
 				},
 			});
@@ -90,14 +97,15 @@ describe('Perl debugger connection', () => {
 			local.kill();
 			conn.perlDebugger.kill();
 
-			assert.equal(local.title(), `perl -d ${FILE_TEST_PL}`);
+			// FIXME: disabled due to format changes
+			// assert.equal(local.title(), `perl -d ${FILE_TEST_PL}`);
 			assert.equal(res.finished, false);
 			assert.equal(res.exception, false);
 			assert.equal(res.ln, 7); // The first code line in test.pl is 5
 		});
 
 		it.skip('Should error when launching ' + FILE_BROKEN_SYNTAX, async () => {
-			const res = <RequestResponse>await asyncAssert.throws(testLaunch(conn, FILE_BROKEN_SYNTAX, DATA_ROOT, [], launchOptions));
+			const res = <RequestResponse>await asyncAssert.throws(testLaunch(conn, FILE_BROKEN_SYNTAX, DATA_ROOT, []));
 
 			assert.equal(res.exception, true, 'Response should have exception set true');
 			assert.equal(res.errors.length, 2, 'Response errors should be 2');
@@ -107,7 +115,6 @@ describe('Perl debugger connection', () => {
 		it('Should take arguments ' + FILE_PRINT_ARGUMENTS, async () => {
 			const res = await testLaunch(conn, FILE_PRINT_ARGUMENTS, DATA_ROOT, [], {
 				args: ['foo=bar', 'test=ok'],
-				...launchOptions,
 			});
 
 			const argv = await conn.getExpressionValue('"@ARGV"');
@@ -120,65 +127,65 @@ describe('Perl debugger connection', () => {
 
 	describe('setFileContext', () => {
 		it('Should be able to set file context', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setFileContext(FILE_MODULE);
 		});
 
 		it('Should be able to set file context on same file twice', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setFileContext(FILE_MODULE);
 			await conn.setFileContext(FILE_MODULE);
 		});
 
 		it('Should throw on unknown file', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await asyncAssert.throws(conn.setFileContext(FILE_FICTIVE));
 		});
 	});
 
 	describe('setBreakPoint', () => {
 		it('Should be able to set break point on line 7 in current file', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 		});
 		it('Should not be able to set breakpoint on line 9 in current file', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await asyncAssert.throws(conn.setBreakPoint(9));
 		});
 		it('Should be able to set break point on line 7 in ' + FILE_TEST_PL, async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7, FILE_TEST_PL);
 		});
 		it('Should not be able to set breakpoint on line 9 in ' + FILE_TEST_PL, async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await asyncAssert.throws(conn.setBreakPoint(9, FILE_TEST_PL));
 		});
 		it('Should be able to set break point on line 4 in ' + FILE_MODULE, async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(4, FILE_MODULE);
 		});
 		it('Should not be able to set breakpoint on line 3 in ' + FILE_MODULE, async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await asyncAssert.throws(conn.setBreakPoint(3, FILE_MODULE));
 		});
 		it('Should not be able to set breakpoint on line 7 in ' + FILE_FICTIVE, async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await asyncAssert.throws(conn.setBreakPoint(7, FILE_FICTIVE));
 		});
 	});
 
 	describe('getBreakPoints', () => {
 		it('Should work if no breakpoints are added', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			assert.deepEqual(await conn.getBreakPoints(), {});
 		});
 		it('Should work if only one file is added', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 			assert.deepEqual(await conn.getBreakPoints(), { [FILE_TEST_PL]: [ 7 ] });
 		});
 		it('Should work if multiple breakpoints are added for one file', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 			await conn.setBreakPoint(8);
 			await conn.setBreakPoint(10);
@@ -188,7 +195,7 @@ describe('Perl debugger connection', () => {
 			assert.deepEqual(await conn.getBreakPoints(), { [FILE_TEST_PL]: [ 7, 8, 10, 11, 12, 13 ] });
 		});
 		it('Should work if multiple breakpoints are added for multiple files', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 			await conn.setBreakPoint(10, FILE_TEST_PL);
 			await conn.setBreakPoint(11, FILE_TEST_PL);
@@ -208,7 +215,7 @@ describe('Perl debugger connection', () => {
 
 	describe('clearBreakPoint', () => {
 		it('Should allow clearing one breakpoint', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 			await conn.setBreakPoint(8);
 			await conn.setBreakPoint(10, FILE_TEST_PL);
@@ -232,7 +239,7 @@ describe('Perl debugger connection', () => {
 
 	describe('clearBreakPoint', () => {
 		it('Should allow clearing all breakpoints', async () => {
-			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+			await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 			await conn.setBreakPoint(7);
 			await conn.setBreakPoint(10, FILE_TEST_PL);
 			await conn.setBreakPoint(4, FILE_MODULE);
@@ -249,14 +256,14 @@ describe('Perl debugger connection', () => {
 	describe('Test debugger', () => {
 		describe('continue', () => {
 			it('Should leave us at line 11 in ' + FILE_TEST_PL, async () => {
-				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 				await conn.setBreakPoint(11, FILE_TEST_PL);
 				const res = await conn.continue();
 				assert.equal(res.ln, 11);
 			});
 
 			it.skip('Should throw an error ' + FILE_BROKEN_CODE, async () => {
-				await testLaunch(conn, FILE_BROKEN_CODE, DATA_ROOT, [], launchOptions);
+				await testLaunch(conn, FILE_BROKEN_CODE, DATA_ROOT, []);
 				await conn.setBreakPoint(11, FILE_BROKEN_CODE);
 				// In between we have broken code
 				await conn.setBreakPoint(13, FILE_BROKEN_CODE);
@@ -273,7 +280,7 @@ describe('Perl debugger connection', () => {
 
 		describe('next', () => {
 			it('Should go to next statement', async () => {
-				let res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+				let res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 				assert.equal(res.ln, 7);
 				res = await conn.next();
 				assert.equal(res.ln, 8);
@@ -282,7 +289,7 @@ describe('Perl debugger connection', () => {
 
 		describe('getPadwalkerVersion', () => {
 			it('should return version of installed padwalker', async () => {
-				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 				expect(conn.padwalkerVersion).toBeDefined();
 				expect(conn.padwalkerVersion.length).toBeGreaterThan(1);
 				expect(Number(conn.padwalkerVersion)).toBeGreaterThan(1);
@@ -291,7 +298,7 @@ describe('Perl debugger connection', () => {
 
 		describe('getVariableList', () => {
 			it('Should get more scope variables types', async function() {
-				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+				await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 				await conn.setBreakPoint(23, FILE_MODULE);
 
 				await conn.continue();
@@ -313,7 +320,7 @@ describe('Perl debugger connection', () => {
 
 		describe('restart', () => {
 			it('Should start from the beginning', async () => {
-				let res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, [], launchOptions);
+				let res = await testLaunch(conn, FILE_TEST_PL, DATA_ROOT, []);
 				assert.equal(res.ln, 7);
 				res = await conn.next();
 				assert.equal(res.ln, 8);
@@ -330,7 +337,7 @@ describe('Perl debugger connection', () => {
 
 		describe.skip('resolveFilename', () => {
 			it('Should resolve filenames', async () => {
-				let res = await testLaunch(conn, FILE_TEST_NESTED_PL, DATA_ROOT, [], launchOptions);
+				let res = await testLaunch(conn, FILE_TEST_NESTED_PL, DATA_ROOT, []);
 				assert.equal(res.ln, 6);
 				const perl5dbPath = await conn.resolveFilename('perl5db.pl');
 				// /System/Library/Perl/5.18/perl5db.pl

--- a/src/tests/data/fork.pl
+++ b/src/tests/data/fork.pl
@@ -1,0 +1,5 @@
+print "main\n";
+my $pid = fork();
+print "pid = $pid\n";
+sleep 2;
+

--- a/src/tests/multisession.test.ts
+++ b/src/tests/multisession.test.ts
@@ -1,0 +1,102 @@
+import assert = require('assert');
+import * as Path from 'path';
+import * as fs from 'fs';
+import {DebugClient} from 'vscode-debugadapter-testsupport';
+import {DebugProtocol} from 'vscode-debugprotocol';
+import { Subject } from 'await-notify';
+
+describe('multisession support', () => {
+
+	const DEBUG_ADAPTER = './out/debugAdapter.js';
+
+	const PROJECT_ROOT = Path.dirname(Path.dirname(__dirname));
+	const DATA_ROOT = Path.join(PROJECT_ROOT, 'src', 'tests', 'data');
+
+	const defaultLaunchConfig = {
+		type: 'perl',
+		request: 'launch',
+		exec: 'perl',
+		execArgs: [],
+		name: 'Perl-Debug',
+		root: DATA_ROOT,
+		inc: [],
+		args: [],
+		stopOnEntry: false,
+		console: 'none',
+		trace: false,
+		debugRaw: true,
+	};
+
+	const Configuration = (obj: Object) => {
+		return Object.assign({}, defaultLaunchConfig, obj);
+	};
+
+	let mainDc: DebugClient;
+
+	beforeEach( () => {
+		mainDc = new DebugClient('node', DEBUG_ADAPTER, 'perl');
+		return mainDc.start();
+	});
+
+	afterEach(() => {
+		mainDc.stop();
+	});
+
+	describe('launch', () => {
+
+		it('forked child can connect', async () => {
+
+			mainDc.on('perl-debug.streamcatcher.data', (x) => {
+				// useful for debugging: console.log(x);
+			});
+
+			const attached = new Subject();
+
+			mainDc.on('perl-debug.attachable.listening', async (evt) => {
+
+				attached.notify();
+
+				const childDc = new DebugClient('node', DEBUG_ADAPTER, 'perl');
+
+				await Promise.all([
+					childDc.waitForEvent('initialized'),
+					childDc.launch(Configuration({
+						type: 'perl',
+						request: 'launch',
+						name: `auto ${evt.body.src.address}:${evt.body.src.port}`,
+						port: evt.body.dst.port,
+						console: "_attach",
+					})),
+					// stopped after fork() returns in the child
+					childDc.assertStoppedLocation('postfork', {
+						line: 3,
+					}),
+				]);
+
+				childDc.stop();
+
+			});
+
+			await Promise.all([
+				mainDc.waitForEvent('initialized'),
+				mainDc.launch(Configuration({
+					program: "fork.pl",
+					stopOnEntry: true,
+					console: 'none',
+					sessions: 'break',
+				})),
+				mainDc.assertStoppedLocation('entry', {
+					line: 1
+				}),
+			]);
+
+			await Promise.all([
+				mainDc.continueRequest({
+					threadId: undefined
+				}),
+				attached
+			]);
+
+		});
+	});
+});


### PR DESCRIPTION
The high level summary is that this adds support for multi-session debugging beyond manually starting several debug sessions. This is needed to support `fork` and similar features, and enables running scripts that start multiple Perl processes (like using `prove` to run a test suite consisting of many Perl scripts) though the debugger. For this a new `launch.json` option is added, called `sessions` that controls whether you want the current behaviour, where attempts to connect to the `RemoteSession` port are rejected, a `watch` mode, and a `break` mode (they basically model `stopOnEntry` for additional processes).

Also:
* adds function breakpoints (I am going to close the other PR in favour of this)
* adds the `EMBED_DEBUG_ADAPTER` compile time option from `mock-debug` that allows running the debug adapter in the same process as the extension, greatly simplifying debugging.
* adds `terminateRequest`, `disconnectRequest` needed to make sure child processes are handled properly
* adds a `launch.json` option `debugLog` which creates an output channel for `logDebug` messages
* enables several tests that have been skipped so far, hopefully Travis will like them better now
* fixes https://github.com/raix/vscode-perl-debug/issues/75
* fixes several instances where `StoppedEvent` did not make it to vscode in the right way
* removes `LaunchOptions` in favour of consistently using `LauchRequestArguments`
* removes `$PATH` forwarding by default. Does not seem necessary with `runInTerminal` anymore, and users can still configure that in `launch.json` through template variables if they need it
* attempts to improve how/when it is reported when new sources have been loaded
* offloads more complex functions into resident subs in the `Devel::vscode` namespace

Missing:
* <s>Tests for multi-session debugging.</s>