### PR TITLE
Added support for perl variable editing during debugging

### DIFF
--- a/src/perlDebug.ts
+++ b/src/perlDebug.ts
@@ -695,14 +695,14 @@ export class PerlDebugSession extends LoggingDebugSession {
 				//
 				//      Quoted invalid expressions are strings and hence are interpolated according to their quotation marks e.g.
 				//
-				//         '$x +'       '$x +'
-				//         "$x +"       "1 +"
+				//         '$x +'       $s = '$x +'
+				//         "$x +"       $s = "1 +"
 				//
 				//      Special case for x'y. Old-style class reference lookalikes are interpreted as strings and not as x::y because it's extremely unlikely
 				//      that actually old-style class references are used by the user in the expression. This way strings with single-quotes will work
 				//      seamlessly (e.g. "There's" remains "There's" intead of becoming "There::s":)
 				//
-				//           x'y        "x'y"
+				//           x'y        $s = "x'y"
 				//
 				//  The above assignment ops provide perl programmers with an intuitive set of assignment operations for everyday use cases.
 

--- a/src/tests/variableParser.test.ts
+++ b/src/tests/variableParser.test.ts
@@ -251,7 +251,7 @@ describe('resolveVariable', () => {
         const variables = variableParser(data, 'local_0');
 		assert.equal(resolveVariable('8', 'HASH(0x7fd26896ecb0)', variables), '$obj->{8}');
 		assert.equal(resolveVariable('$bar', 'local_0', variables), '$bar');
-		assert.equal(resolveVariable('8', 'ARRAY(0x7fd269242a50)', variables), '@list1->[8]');
-		assert.equal(resolveVariable('ownFoo', 'HASH(0x7fd26892c6c0)', variables), '$obj->{ownObj}->{ownFoo}');
+		assert.equal(resolveVariable('8', 'ARRAY(0x7fd269242a50)', variables), '$list1[8]');
+		assert.equal(resolveVariable('ownFoo', 'HASH(0x7fd26892c6c0)', variables), '$obj->{ownObj}{ownFoo}');
 	});
 });

--- a/src/variableParser.ts
+++ b/src/variableParser.ts
@@ -125,9 +125,19 @@ export function resolveVariable(name, variablesReference, variables) {
 		limit++;
 	}
 
-	result.unshift(key);
+	// return the var if it's a simple non-composite scalar var
+	if (!result.length) { return key; }
 
-	return result.join('->');
+	// this is a structured var: array (@), hash (%), object ($) or a ref ($) to them
+	if (/^\$/.test(key)) { result.unshift(key,'->'); } // it's a ref, so we need $ar->[k], $hr->{k}, $obj->{k}
+		else {
+			// non-ref: @a or %h, so we need $a[k] and $h{k}
+			// So we replace the @ and % sigils with $
+			key = key.replace(/^(@|%)/,'$');
+			result.unshift(key);
+		}
+
+	return result.join(''); // combine the var name with the dereference chain
 }
 
 /**


### PR DESCRIPTION
Hi, Raix,

I added perl variable editing support to your Perl Debug so now you can edit perl variables during debugging. All kinds of intuitive assignment operations are supported. See the explanation and the examples in perlDebug.ts.

Please push this new feature out to the VS Code marketplace so that this new feature is available to all.
Thanks,
GK