### PR TITLE
Fix file path regex pattern in stack trace response

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1089,7 +1089,7 @@ export class perlDebuggerConnection extends EventEmitter {
 		res.data.forEach((line, i) => {
 			// > @ = DB::DB called from file 'lib/Module2.pm' line 5
 			// > . = Module2::test2() called from file 'test.pl' line 12
-			const m = line.match(/^(\S+) = (\S+) called from file \'(\S+)\' line ([0-9]+)$/);
+			const m = line.match(/^(\S+) = (\S+) called from file \'((?:(?:[a-zA-Z]:)?[\\/]+)?(?:[^\\/\r\n]+[\\/]+)*[^\\/\r\n]+)\' line ([0-9]+)$/);
 
 			if (m !== null) {
 				const [, v, caller, name, ln] = m;


### PR DESCRIPTION
The original regex pattern would encounter for characters other than white space (\S)
as part of the file path. In some cases this is not true.
Apparently a space is a valid file path character and must be encountered for.

This bug would prevent the VSCode from stopping on break points, whereas
the actual Perl debugger would indicate a break point was hit.

Fixes #104 